### PR TITLE
Fixed custom styles for dateNameStyle

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -241,7 +241,7 @@ class CalendarDay extends Component {
         >
           {this.props.showDayName && (
             <Text
-              style={[dateNameStyle, { fontSize: this.state.dateNameFontSize }]}
+              style={[{ fontSize: this.state.dateNameFontSize }, dateNameStyle]}
               allowFontScaling={this.props.allowDayTextScaling}
             >
               {this.props.date.format("ddd").toUpperCase()}


### PR DESCRIPTION
I have inverted the params because in the old way the fontSize was overwritten by the component props/state